### PR TITLE
Apply policy for openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-alpine
 
 LABEL maintainer="Atomist <docker@atomist.com>"
 


### PR DESCRIPTION
Apply policy `docker-base-image::openjdk`:

_Docker base image_
```openjdk (8-alpine)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:docker-base-image::openjdk=a51cee2d1656b139ec1757b07446a58d1a367c26356061fbbac8068e42b42309]</code>
</details>